### PR TITLE
fix: No tag found that was able to satisfy 0.3.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "duoshuo": "0.5.2",
     "marked": "~0.3.2",
     "highlightjs": "~8.0.0",
-    "chill": "0.3.1",
+    "chill": "0.3.0",
     "ninja": "0.1.1",
     "oclazyload": "~0.5.2"
   },


### PR DESCRIPTION
`bower install`时报错信息：

``` shell
bower ENORESTARGET  No tag found that was able to satisfy 0.3.1

Additional error details:
Available versions in git://github.com/airpub/chill.git: 0.3.0, 0.2.0, 0.1.4, 0.1.3, 0.1.2, 0.1.1, 0.1.0
```
